### PR TITLE
Changes for FreeCad 0.21.2

### DIFF
--- a/MakeBoxPanel.py
+++ b/MakeBoxPanel.py
@@ -92,17 +92,15 @@ class ViewProviderGroupBox: # self PythonFeatureViewProvider
     def onChanged(self, vp, prop):
         pass
 
-    def __getstate__(self):
-        ''' When saving the document this object gets stored using Python's cPickle module.
-        Since we have some un-pickable here -- the Coin stuff -- we must define this method
-        to return a tuple of all pickable objects or None.
-        '''
+    def dumps(self):
+        """When saving the document this object gets stored using Python's json module.\
+                Since we have some un-serializable parts here -- the Coin stuff -- we must define this method\
+                to return a tuple of all serializable objects or None."""
         return None
 
-    def __setstate__(self, state):
-        ''' When restoring the pickled object from document we have the chance to set some
-        internals here. Since no data were pickled nothing needs to be done here.
-        '''
+    def loads(self, state):
+        """When restoring the serialized object from document we have the chance to set some internals here.\
+                Since no data were serialized nothing needs to be done here."""
         return None
 
     def attach(self, vobj):

--- a/MakeBoxPanel.py
+++ b/MakeBoxPanel.py
@@ -117,10 +117,11 @@ class MakeBox:
         self.form = []
         self.main_widget = QtGui.QWidget()
         self.main_widget.setWindowTitle("Make box")
-        self.parts_vbox = QtGui.QGridLayout(self.main_widget)
+        self.parts_vbox = QtGui.QGridLayout()
+        self.main_widget.setLayout(self.parts_vbox)
         self.form.append(self.main_widget)
 
-        self.preview_button = QtGui.QPushButton('Preview', self.main_widget)
+        self.preview_button = QtGui.QPushButton('Preview')
         self.parts_vbox.addWidget(self.preview_button, 0, 0, 1, 2)
         self.preview_button.clicked.connect(self.preview)
 
@@ -137,12 +138,13 @@ class MakeBox:
         self.param_widget = QtGui.QWidget()
         self.param_widget.setWindowTitle("Parameters")
         self.form.append(self.param_widget)
-        self.params_vlayout = QtGui.QVBoxLayout(self.param_widget)
+        self.params_vlayout = QtGui.QVBoxLayout()
+        self.param_widget.setLayout(self.params_vlayout)
 
-        dim_group_box, grid = self.dim_box_param.get_group_box(self.param_widget)
-        length_group_box, grid = self.general_box_param.get_group_box(self.param_widget)
-        top_group_box, grid = self.top_box_param.get_group_box(self.param_widget)
-        bottom_group_box, grid = self.bottom_box_param.get_group_box(self.param_widget)
+        dim_group_box = self.dim_box_param.get_group_box(self.param_widget)
+        length_group_box = self.general_box_param.get_group_box(self.param_widget)
+        top_group_box = self.top_box_param.get_group_box(self.param_widget)
+        bottom_group_box = self.bottom_box_param.get_group_box(self.param_widget)
 
         self.params_vlayout.addWidget(dim_group_box)
         self.params_vlayout.addWidget(length_group_box)

--- a/MakeRoundedBoxPanel.py
+++ b/MakeRoundedBoxPanel.py
@@ -120,10 +120,11 @@ class MakeRoundedBox:
         self.form = []
         self.main_widget = QtGui.QWidget()
         self.main_widget.setWindowTitle("Make rounded box")
-        self.parts_vbox = QtGui.QGridLayout(self.main_widget)
+        self.parts_vbox = QtGui.QGridLayout()
+        self.main_widget.setLayout(self.parts_vbox)
         self.form.append(self.main_widget)
 
-        self.preview_button = QtGui.QPushButton('Preview', self.main_widget)
+        self.preview_button = QtGui.QPushButton('Preview')
         self.parts_vbox.addWidget(self.preview_button, 0, 0, 1, 2)
         self.preview_button.clicked.connect(self.preview)
 
@@ -139,11 +140,12 @@ class MakeRoundedBox:
         self.param_widget = QtGui.QWidget()
         self.param_widget.setWindowTitle("Parameters")
         self.form.append(self.param_widget)
-        self.params_vlayout = QtGui.QVBoxLayout(self.param_widget)
+        self.params_vlayout = QtGui.QVBoxLayout()
+        self.param_widget.setLayout(self.params_vlayout)
 
-        dim_group_box, grid = self.box_properties.get_group_box(self.param_widget)
-        top_group_box, grid = self.top_box_param.get_group_box(self.param_widget)
-        bottom_group_box, grid = self.bottom_box_param.get_group_box(self.param_widget)
+        dim_group_box = self.box_properties.get_group_box(self.param_widget)
+        top_group_box = self.top_box_param.get_group_box(self.param_widget)
+        bottom_group_box = self.bottom_box_param.get_group_box(self.param_widget)
 
         self.params_vlayout.addWidget(dim_group_box)
         self.params_vlayout.addWidget(top_group_box)

--- a/MakeRoundedBoxPanel.py
+++ b/MakeRoundedBoxPanel.py
@@ -94,17 +94,15 @@ class ViewProviderGroupRoundedBox:
     def onChanged(self, vp, prop):
         pass
 
-    def __getstate__(self):
-        ''' When saving the document this object gets stored using Python's cPickle module.
-        Since we have some un-pickable here -- the Coin stuff -- we must define this method
-        to return a tuple of all pickable objects or None.
-        '''
+    def dumps(self):
+        """When saving the document this object gets stored using Python's json module.\
+                Since we have some un-serializable parts here -- the Coin stuff -- we must define this method\
+                to return a tuple of all serializable objects or None."""
         return None
 
-    def __setstate__(self, state):
-        ''' When restoring the pickled object from document we have the chance to set some
-        internals here. Since no data were pickled nothing needs to be done here.
-        '''
+    def loads(self, state):
+        """When restoring the serialized object from document we have the chance to set some internals here.\
+                Since no data were serialized nothing needs to be done here."""
         return None
 
     def attach(self, vobj):

--- a/panel/crosspiece.py
+++ b/panel/crosspiece.py
@@ -177,17 +177,15 @@ class CrossPieceViewProvider:
     def onChanged(self, vp, prop):
         pass
 
-    def __getstate__(self):
-        ''' When saving the document this object gets stored using Python's cPickle module.
-        Since we have some un-pickable here -- the Coin stuff -- we must define this method
-        to return a tuple of all pickable objects or None.
-        '''
+    def dumps(self):
+        """When saving the document this object gets stored using Python's json module.\
+                Since we have some un-serializable parts here -- the Coin stuff -- we must define this method\
+                to return a tuple of all serializable objects or None."""
         return None
 
-    def __setstate__(self, state):
-        ''' When restoring the pickled object from document we have the chance to set some
-        internals here. Since no data were pickled nothing needs to be done here.
-        '''
+    def loads(self, state):
+        """When restoring the serialized object from document we have the chance to set some internals here.\
+                Since no data were serialized nothing needs to be done here."""
         return None
 
     def attach(self, vobj):

--- a/panel/crosspiece.py
+++ b/panel/crosspiece.py
@@ -230,24 +230,24 @@ class CrossPiece(TreePanel):
 
     def init_tree_widget(self):
         #Preview button
-        v_box = QtGui.QVBoxLayout(self.tree_widget)
-        preview_button = QtGui.QPushButton('Preview', self.tree_widget)
+        v_box = QtGui.QVBoxLayout()
+        preview_button = QtGui.QPushButton('Preview')
         preview_button.clicked.connect(self.preview)
-        #self.fast_preview = QtGui.QCheckBox("Fast preview", self.tree_widget)
-        line = QtGui.QFrame(self.tree_widget)
+        #self.fast_preview = QtGui.QCheckBox("Fast preview")
+        line = QtGui.QFrame()
         line.setFrameShape(QtGui.QFrame.HLine);
         line.setFrameShadow(QtGui.QFrame.Sunken);
-        h_box = QtGui.QHBoxLayout(self.tree_widget)
+        h_box = QtGui.QHBoxLayout()
         h_box.addWidget(preview_button)
         #h_box.addWidget(self.fast_preview)
         v_box.addLayout(h_box)
         v_box.addWidget(line)
         self.tree_vbox.addLayout(v_box)
         # Add part buttons
-        h_box = QtGui.QHBoxLayout(self.tree_widget)
-        add_parts_button = QtGui.QPushButton('Add parts', self.tree_widget)
+        h_box = QtGui.QHBoxLayout()
+        add_parts_button = QtGui.QPushButton('Add parts')
         add_parts_button.clicked.connect(self.add_parts)
-        add_same_part_button = QtGui.QPushButton('Add same parts', self.tree_widget)
+        add_same_part_button = QtGui.QPushButton('Add same parts')
         add_same_part_button.clicked.connect(self.add_same_parts)
         h_box.addWidget(add_parts_button)
         h_box.addWidget(add_same_part_button)
@@ -256,11 +256,11 @@ class CrossPiece(TreePanel):
         self.selection_model = self.tree_view_widget.selectionModel()
         self.selection_model.selectionChanged.connect(self.selection_changed)
         self.tree_vbox.addWidget(self.tree_view_widget)
-        remove_item_button = QtGui.QPushButton('Remove item', self.tree_widget)
+        remove_item_button = QtGui.QPushButton('Remove item')
         remove_item_button.clicked.connect(self.remove_items)
         self.tree_vbox.addWidget(remove_item_button)
         # test layout
-        self.edit_items_layout = QtGui.QVBoxLayout(self.tree_widget)
+        self.edit_items_layout = QtGui.QVBoxLayout()
         self.tree_vbox.addLayout(self.edit_items_layout)
 
 class CrossPieceCommand:

--- a/panel/livinghinge.py
+++ b/panel/livinghinge.py
@@ -57,21 +57,23 @@ class LivingHingesPanel:
         self.param_widget = QtGui.QWidget()
         self.param_widget.setWindowTitle("Global parameters")
         self.form.append(self.param_widget)
-        self.params_vlayout = QtGui.QVBoxLayout(self.param_widget)
+        self.params_vlayout = QtGui.QVBoxLayout()
+        self.param_widget.setLayout(self.params_vlayout)
 
-        global_box, grid = self.global_properties_widget.get_group_box(self.param_widget)
+        global_box = self.global_properties_widget.get_group_box(self.param_widget)
         self.params_vlayout.addWidget(global_box)
 
         self.main_con_widget = QtGui.QWidget()
         self.main_con_widget.setWindowTitle("Living hinges")
-        self.parts_vbox = QtGui.QVBoxLayout(self.main_con_widget)
+        self.parts_vbox = QtGui.QVBoxLayout()
+        self.main_con_widget.setLayout(self.parts_vbox)
         self.form.append(self.main_con_widget)
 
-        self.con_button = QtGui.QPushButton('Add connection', self.main_con_widget)
+        self.con_button = QtGui.QPushButton('Add connection')
         self.parts_vbox.addWidget(self.con_button)
         self.con_button.clicked.connect(self.add_connection)
 
-        self.connection_vbox = QtGui.QVBoxLayout(self.param_widget)
+        self.connection_vbox = QtGui.QVBoxLayout()
         self.parts_vbox.addLayout(self.connection_vbox)
 
         self.connection_widget_list = []
@@ -163,7 +165,7 @@ class LivingHingesPanel:
                     self.connection_widget_list[index].get_properties().compute_min_link(link_clearance)
         self.remove_items_widgets()
         for con_widget in self.connection_widget_list:
-            group_box, grid = con_widget.get_group_box(self.main_con_widget)
+            group_box = con_widget.get_group_box(self.main_con_widget)
             self.connection_vbox.addWidget(group_box)
         return
 

--- a/panel/livinghinge.py
+++ b/panel/livinghinge.py
@@ -245,17 +245,15 @@ class LivingHingesViewProvider:
     def onChanged(self, vp, prop):
         pass
 
-    def __getstate__(self):
-        ''' When saving the document this object gets stored using Python's cPickle module.
-        Since we have some un-pickable here -- the Coin stuff -- we must define this method
-        to return a tuple of all pickable objects or None.
-        '''
+    def dumps(self):
+        """When saving the document this object gets stored using Python's json module.\
+                Since we have some un-serializable parts here -- the Coin stuff -- we must define this method\
+                to return a tuple of all serializable objects or None."""
         return None
 
-    def __setstate__(self, state):
-        ''' When restoring the pickled object from document we have the chance to set some
-        internals here. Since no data were pickled nothing needs to be done here.
-        '''
+    def loads(self, state):
+        """When restoring the serialized object from document we have the chance to set some internals here.\
+                Since no data were serialized nothing needs to be done here."""
         return None
 
     def attach(self, vobj):

--- a/panel/multiplejoins.py
+++ b/panel/multiplejoins.py
@@ -196,17 +196,15 @@ class MultipleJoinViewProvider:
     def onChanged(self, vp, prop):
         pass
 
-    def __getstate__(self):
-        ''' When saving the document this object gets stored using Python's cPickle module.
-        Since we have some un-pickable here -- the Coin stuff -- we must define this method
-        to return a tuple of all pickable objects or None.
-        '''
+    def dumps(self):
+        """When saving the document this object gets stored using Python's json module.\
+                Since we have some un-serializable parts here -- the Coin stuff -- we must define this method\
+                to return a tuple of all serializable objects or None."""
         return None
 
-    def __setstate__(self, state):
-        ''' When restoring the pickled object from document we have the chance to set some
-        internals here. Since no data were pickled nothing needs to be done here.
-        '''
+    def loads(self, state):
+        """When restoring the serialized object from document we have the chance to set some internals here.\
+                Since no data were serialized nothing needs to be done here."""
         return None
 
     def attach(self, vobj):

--- a/panel/partmat.py
+++ b/panel/partmat.py
@@ -87,7 +87,7 @@ class PartLink(ParamWidget):
         grid.addWidget(title, 1, 0, 1, 2)
         group_box.setLayout(grid)
         group_box.setTitle(self.name)
-        return group_box, grid
+        return group_box
 
 
 class PartsList(object):

--- a/panel/propertieslist.py
+++ b/panel/propertieslist.py
@@ -25,11 +25,11 @@ class PropertiesList():
     def pop(self, index):
         self.lst.pop(index)
 
-    def __getstate__(self):
+    def dumps(self):
         json_string = json.dumps([ob.__dict__ for ob in self.lst])
         return json_string
 
-    def __setstate__(self, state):
+    def loads(self, state):
         self.lst = []
         bckp = json.loads(state)
         for obj in bckp:

--- a/panel/tab.py
+++ b/panel/tab.py
@@ -125,7 +125,7 @@ class TabLink(ParamWidget):
         grid.addWidget(title, 1, 0, 1, 2)
         group_box.setLayout(grid)
         group_box.setTitle(self.name)
-        return group_box, grid
+        return group_box
 
 
 class TabsList(object):

--- a/panel/toolwidget.py
+++ b/panel/toolwidget.py
@@ -46,7 +46,7 @@ class ParamWidget(object):
 
     def get_grid(self):
         row_index = 0
-        widgets_grid = QtGui.QGridLayout(self.form)
+        widgets_grid = QtGui.QGridLayout()
         for widget in self.widget_list:
             self.create_item(widget, widgets_grid, row_index)
             row_index += 1
@@ -127,7 +127,7 @@ class ParamWidget(object):
         self.form = widget
         grid = self.get_grid()
         group_box.setLayout(grid)
-        return group_box, grid
+        return group_box
 
     def properties(self):
         return self.object_property

--- a/panel/treepanel.py
+++ b/panel/treepanel.py
@@ -74,7 +74,8 @@ class TreePanel(object):
         self.tree_widget = QtGui.QWidget()
         self.tree_widget.setObjectName("TreePanel")
         self.tree_widget.setWindowTitle(title)
-        self.tree_vbox = QtGui.QVBoxLayout(self.tree_widget)
+        self.tree_vbox = QtGui.QVBoxLayout()
+        self.tree_widget.setLayout(self.tree_vbox)
         self.form.append(self.tree_widget)
         self.model = TreeModel()
         self.tree_view_widget = QtGui.QTreeView()
@@ -107,14 +108,14 @@ class TreePanel(object):
         raise ValueError("Must overloaded")
 
     def init_tree_widget(self):
-        v_box = QtGui.QVBoxLayout(self.tree_widget)
-        preview_button = QtGui.QPushButton('Preview', self.tree_widget)
+        v_box = QtGui.QVBoxLayout()
+        preview_button = QtGui.QPushButton('Preview')
         preview_button.clicked.connect(self.abs_preview)
-        self.fast_preview = QtGui.QCheckBox("Fast preview", self.tree_widget)
-        line = QtGui.QFrame(self.tree_widget)
+        self.fast_preview = QtGui.QCheckBox("Fast preview")
+        line = QtGui.QFrame()
         line.setFrameShape(QtGui.QFrame.HLine);
         line.setFrameShadow(QtGui.QFrame.Sunken);
-        h_box = QtGui.QHBoxLayout(self.tree_widget)
+        h_box = QtGui.QHBoxLayout()
         h_box.addWidget(preview_button)
         h_box.addWidget(self.fast_preview)
         v_box.addLayout(h_box)
@@ -122,23 +123,23 @@ class TreePanel(object):
         self.tree_vbox.addLayout(v_box)
 
         # Add part buttons
-        h_box = QtGui.QHBoxLayout(self.tree_widget)
-        add_parts_button = QtGui.QPushButton('Add parts', self.tree_widget)
+        h_box = QtGui.QHBoxLayout()
+        add_parts_button = QtGui.QPushButton('Add parts')
         add_parts_button.clicked.connect(self.add_parts)
-        add_same_part_button = QtGui.QPushButton('Add same parts', self.tree_widget)
+        add_same_part_button = QtGui.QPushButton('Add same parts')
         add_same_part_button.clicked.connect(self.add_same_parts)
         h_box.addWidget(add_parts_button)
         h_box.addWidget(add_same_part_button)
         self.tree_vbox.addLayout(h_box)
         # Add faces buttons
-        h_box = QtGui.QHBoxLayout(self.tree_widget)
-        self.tab_type_box = QtGui.QComboBox(self.tree_widget)
+        h_box = QtGui.QHBoxLayout()
+        self.tab_type_box = QtGui.QComboBox()
         self.tab_type_box.addItems([TabProperties.TYPE_TAB, TabProperties.TYPE_T_SLOT,
                                     TabProperties.TYPE_CONTINUOUS])#, TabProperties.TYPE_FLEX])
         h_box.addWidget(self.tab_type_box)
-        add_faces_button = QtGui.QPushButton('Add faces', self.tree_widget)
+        add_faces_button = QtGui.QPushButton('Add faces')
         add_faces_button.clicked.connect(self.add_tabs)
-        add_same_faces_button = QtGui.QPushButton('Add same faces', self.tree_widget)
+        add_same_faces_button = QtGui.QPushButton('Add same faces')
         add_same_faces_button.clicked.connect(self.add_same_tabs)
         h_box.addWidget(add_faces_button)
         h_box.addWidget(add_same_faces_button)
@@ -147,15 +148,15 @@ class TreePanel(object):
         self.selection_model = self.tree_view_widget.selectionModel()
         self.selection_model.selectionChanged.connect(self.selection_changed)
         self.tree_vbox.addWidget(self.tree_view_widget)
-        remove_item_button = QtGui.QPushButton('Remove item', self.tree_widget)
+        remove_item_button = QtGui.QPushButton('Remove item')
         remove_item_button.clicked.connect(self.remove_items)
         self.tree_vbox.addWidget(remove_item_button)
-        line = QtGui.QFrame(self.tree_widget)
+        line = QtGui.QFrame()
         line.setFrameShape(QtGui.QFrame.HLine)
         line.setFrameShadow(QtGui.QFrame.Sunken)
         self.tree_vbox.addWidget(line)
         # test layout
-        self.edit_items_layout = QtGui.QVBoxLayout(self.tree_widget)
+        self.edit_items_layout = QtGui.QVBoxLayout()
         self.tree_vbox.addLayout(self.edit_items_layout)
 
     def check_parts(self, parts):
@@ -304,7 +305,7 @@ class TreePanel(object):
                 FreeCADGui.Selection.addSelection(fobj)
 
                 self.edited_items.append(widget)
-                groupx_box, grid = widget.get_group_box(self.tree_widget)
+                groupx_box = widget.get_group_box(self.tree_widget)
                 self.edit_items_layout.addWidget(groupx_box)
 
         for index in tab_indexes:
@@ -320,7 +321,7 @@ class TreePanel(object):
             FreeCADGui.Selection.addSelection(fobj, tab.face_name)
 
             self.edited_items.append(widget)
-            groupx_box, grid = widget.get_group_box(self.tree_widget)
+            groupx_box = widget.get_group_box(self.tree_widget)
             self.edit_items_layout.addWidget(groupx_box)
 
         for index in tab_indexes:
@@ -346,24 +347,25 @@ class TreePanel(object):
         self.params_widget = QtGui.QWidget()
         self.params_widget.setObjectName("ParamsPanel")
         self.params_widget.setWindowTitle("Parameters")
-        self.params_vbox = QtGui.QVBoxLayout(self.params_widget)
-        QtGui.QWidget().setLayout(self.params_vbox)
-        parts_vbox = QtGui.QGridLayout(self.params_widget)
-        self.hide_button = QtGui.QPushButton('Hide others', self.params_widget)
+        self.params_vbox = QtGui.QVBoxLayout()
+        self.params_widget.setLayout(self.params_vbox)
+        parts_vbox = QtGui.QGridLayout()
+        self.params_widget.setLayout(parts_vbox)
+        self.hide_button = QtGui.QPushButton('Hide others')
         parts_vbox.addWidget(self.hide_button, 0, 0)
         self.hide_button.clicked.connect(self.hide_others)
-        self.show_button = QtGui.QPushButton('Show all', self.params_widget)
+        self.show_button = QtGui.QPushButton('Show all')
         parts_vbox.addWidget(self.show_button, 0, 1)
         self.show_button.clicked.connect(self.show_initial_objects)
 
-        self.set_transparency_button = QtGui.QPushButton('Set transparent', self.params_widget)
+        self.set_transparency_button = QtGui.QPushButton('Set transparent')
         parts_vbox.addWidget(self.set_transparency_button, 1, 0)
         self.set_transparency_button.clicked.connect(self.set_transparency)
-        self.reset_transparency_button = QtGui.QPushButton('Restore transparent', self.params_widget)
+        self.reset_transparency_button = QtGui.QPushButton('Restore transparent')
         parts_vbox.addWidget(self.reset_transparency_button, 1, 1)
         self.reset_transparency_button.clicked.connect(self.restore_transparency)
 
-        preview_button = QtGui.QPushButton('Preview', self.params_widget)
+        preview_button = QtGui.QPushButton('Preview')
         parts_vbox.addWidget(preview_button,2,0,1,2)
         preview_button.clicked.connect(self.preview)
 


### PR DESCRIPTION
- In FreeCAD 0.21.2, the methods **__setstate__** and **__getstate__** used to serialize and deserialize a  object were renamed **dumps** and **loads**.
- The warning message `QLayout: Attempting to add QLayout "" to QWidget "TreePanel", which already has a layout` is due to the layout constructor. According to the documentation, when passing a parent widget to a layout constructor, the layout is set directly as the top-level layout for the parent. There can be only one top-level layout for a widget.
